### PR TITLE
support gpu spmd

### DIFF
--- a/xla/pjrt/pjrt_client.h
+++ b/xla/pjrt/pjrt_client.h
@@ -1391,6 +1391,12 @@ class PjRtLoadedExecutable : public PjRtExecutable {
     return Execute(std::move(argument_handles), options, returned_futures);
   }
 
+  virtual StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>> ExecuteLocal(
+      absl::Span<const std::vector<PjRtBuffer*>> argument_handles,
+      const ExecuteOptions& options,
+      std::optional<PjRtFuture<Status>>& returned_future) {
+  }
+
   // Execute the assigned replica/partition on a given `device`. Requires
   // executable has a device_assignment, `device` is present in the
   // device_assignment and addressable by the client.

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -2881,6 +2881,7 @@ PjRtStreamExecutorLoadedExecutable::Execute(
     auto& statusor = results[i];
     if (!statusor.ok()) {
       if (returned_futures.has_value()) {
+        VLOG(0) << "returned_futures clear";
         returned_futures->clear();
       }
       if (num_addressable_devices == 1) {
@@ -2900,6 +2901,44 @@ PjRtStreamExecutorLoadedExecutable::Execute(
     }
   }
   return wrapped_results;
+}
+
+StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>
+PjRtStreamExecutorLoadedExecutable::ExecuteLocal(
+    absl::Span<const std::vector<PjRtBuffer*>> argument_handles,
+    const ExecuteOptions& options,
+    std::optional<PjRtFuture<Status>>& returned_future) {
+  if (device_assignment_ == nullptr) {
+    return InvalidArgument("Execute expects a non-null device_assignment");
+  }
+
+  RunId run_id;
+  tsl::profiler::TraceMeProducer activity(
+      "PjRtStreamExecutorLoadedExecutable::Execute",
+      tsl::profiler::ContextType::kPjRt, run_id.ToInt());
+
+  const int num_addressable_devices = addressable_devices_.size();
+
+  if (argument_handles.size() != num_addressable_devices) {
+    return InvalidArgument(
+        "Attempted to execute with %d argument lists when local device "
+        "count is %d (total replica count: %d, partition count: %d)",
+        argument_handles.size(), num_addressable_devices, num_replicas(),
+        num_partitions());
+  }
+
+  VLOG(1) << "Executing computation " << name()
+          << "; num_replicas=" << num_replicas()
+          << " num_partitions=" << num_partitions()
+          << " num_addressable_devices=" << num_addressable_devices;
+  TF_ASSIGN_OR_RETURN(
+  auto result,
+  ExecuteHelper(argument_handles[0],
+                addressable_device_logical_ids_[0].replica,
+                addressable_device_logical_ids_[0].partition, run_id,
+                options, true));
+  returned_future = std::move(result.future);
+  return std::move(result.buffers);
 }
 
 StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>>

--- a/xla/pjrt/pjrt_stream_executor_client.cc
+++ b/xla/pjrt/pjrt_stream_executor_client.cc
@@ -2881,7 +2881,6 @@ PjRtStreamExecutorLoadedExecutable::Execute(
     auto& statusor = results[i];
     if (!statusor.ok()) {
       if (returned_futures.has_value()) {
-        VLOG(0) << "returned_futures clear";
         returned_futures->clear();
       }
       if (num_addressable_devices == 1) {

--- a/xla/pjrt/pjrt_stream_executor_client.h
+++ b/xla/pjrt/pjrt_stream_executor_client.h
@@ -841,6 +841,12 @@ class PjRtStreamExecutorLoadedExecutable : public PjRtLoadedExecutable {
       std::optional<std::vector<PjRtFuture<Status>>>& returned_futures)
       override;
 
+  using PjRtLoadedExecutable::ExecuteLocal;
+  StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>> ExecuteLocal(
+      absl::Span<const std::vector<PjRtBuffer*>> argument_handles,
+      const ExecuteOptions& options,
+      std::optional<PjRtFuture<Status>>& returned_future) override;
+
   using PjRtLoadedExecutable::ExecuteSharded;
   StatusOr<std::vector<std::unique_ptr<PjRtBuffer>>> ExecuteSharded(
       absl::Span<PjRtBuffer* const> argument_handles, PjRtDevice* device,

--- a/xla/pjrt/pjrt_stream_executor_client_test.cc
+++ b/xla/pjrt/pjrt_stream_executor_client_test.cc
@@ -19,7 +19,6 @@ limitations under the License.
 #include <string>
 #include <utility>
 #include <vector>
-#include <iostream>
 
 #include <gmock/gmock.h>
 #include "absl/functional/any_invocable.h"
@@ -119,7 +118,7 @@ Status LocalExecute(
 
 TEST(PjRtStreamExecutorClientTest, LocalExecute) {
   // f(a, a)
-  auto status = ExecuteWithSameInputBuffer([](XlaBuilder& builder) {});
+  auto status = LocalExecute([](XlaBuilder& builder) {});
   ASSERT_TRUE(status.ok());
 }
 


### PR DESCRIPTION
During gpu training, each gpu corresponds to a process, so each gpu can only get its own device information for executing subgraphs, so it is necessary to modify the underlying logic of open xla to support local execute.
Using the original logic would result in a coredump when the result of the computation is retrieved.